### PR TITLE
Added power support for the travis.yml file with ppc64le. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@
 # Cf. http://docs.travis-ci.com/user/languages/go/
 
 language: go
+arch:
+ - amd64
+ - ppc64le


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing